### PR TITLE
perf: Batch commits in populate_dependent_tables - 5x speedup

### DIFF
--- a/src/tklr/model.py
+++ b/src/tklr/model.py
@@ -2816,7 +2816,7 @@ class DatabaseManager:
             self.cursor.execute(
                 "UPDATE Records SET processed = 1 WHERE id = ?", (record_id,)
             )
-        self.conn.commit()
+        # self.conn.commit()  # Moved to populate_dependent_tables()
 
     def get_events_for_period(self, start_date: datetime, end_date: datetime):
         """
@@ -3514,7 +3514,7 @@ class DatabaseManager:
                     ),
                 )
 
-        self.conn.commit()
+        # self.conn.commit()  # PERF: Batched at end of populate_all_urgency()
 
     def populate_all_urgency(self):
         self.cursor.execute("DELETE FROM Urgency")


### PR DESCRIPTION
Hello Dan,

I had a vie coding sessio with Claude not accepting the fact that long-waiting-for app is so slow on my machine...here is the result. :wink: 

## Problem
On Linux systems, `tklr --home examples days` was taking 4.5s vs 0.557s on M1 Mac (8x slower), making it unusable as a CLI tool.

## Root Cause
Profiling revealed 251 commits were being executed, with commits inside loops causing excessive `fsync()` calls:
- `generate_datetimes_for_record`: 164 commits (one per record)
- `populate_urgency_from_record`: 57 commits (one per task)

Each commit forces a disk sync, and on Linux this was dominating execution time (74%).

## Solution
Removed commits from inner functions, keeping only the final commit in `populate_all_urgency()`. This batches all database operations into a single transaction.

**Changed lines:**
- Line 2819: Commented out commit in `generate_datetimes_for_record`
- Line 3517: Commented out commit in `populate_urgency_from_record`

## Results
- **Before**: 4.5s (251 commits)
- **After**: 0.89s (48 commits)
- **Speedup**: 5.0x
- **Commits overhead**: 74% → 8% of execution time

Performance now comparable to M1 Mac (1.6x gap vs 8x), making tklr viable as a responsive CLI tool on Linux.

## Testing
Tested on:
- Platform: Linux Mint 22 (Debian-based), btrfs filesystem
- Python: 3.12.3
- Database: Both `examples/` and real migrated etm data (~324 records)

Fixes #24.